### PR TITLE
feat: migrate commits from Flatline Server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,8 @@ EXPOSE 8080
 
 # Required, along with libsgx-quote-ex, for out-of-proc attestation. See
 # https://docs.microsoft.com/en-us/azure/confidential-computing/confidential-nodes-aks-addon
-ENV SGX_AESM_ADDR=1
+# FLT(uoemai): Allow SGX to run in simulation mode.
+# ENV SGX_AESM_ADDR=1
 
 RUN groupadd --gid 10000 cds && useradd --uid 10000 --gid 10000 cds
 USER 10000


### PR DESCRIPTION
This PR migrates the relevant commits from the Flatline Server monorepo to this repository.

A single commit from the following PR has been migrated:
https://github.com/mollyim/flatline-server/pull/34
https://github.com/mollyim/flatline-server/pull/34/commits/73f1b19b97939fc0e3d6d0345bb8473cfa80d784